### PR TITLE
Remove Mobi Directory Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Currently, this is not built for anything outside of the MOBI Organization.
-  
-  
+
+
 
 # ng-generate
 
@@ -16,9 +16,30 @@ npm link
 This will install the project globally to your system and then `npm link` will link it to the cloned repository. This way, when an update is pushed, you can simply pull the update and not have to worry about re-installing the package.
 
 ### Usage
-ngGenerate is a project generator for AngularJS 1.6.x. This package does require that you are in the `pie` directory in order to place the files in the correct location. These generated files are restricted to the mobi module, for the moment. The `ngen generate` command is used to generate a file. `ngen generate` accepts 2 arguments, the **filetype** and the **filename**. The filename should be dasherized and lowercase. After generating the files, you will still need to apply them to your manifest files directly in order to use them.
+ngGenerate is a project generator for AngularJS 1.6.x. These generated files are restricted to the `mobi` module, for the moment, so you will need to update the module name if you are generating files that are not for the `mobi` module. The `ngen generate` command is used to generate a file. `ngen generate` accepts 2 arguments, the **filetype** and the **filename**. The filename should be dasherized and lowercase. After generating the files, you will still need to apply them to your manifest files directly in order to use them.
 
-Currently, you can only generate top level files. A future version of this tool will allow you to generate new files inside of an existing directory.
+This will generate a directory, containing each of the generated files, inside of a components, services or directives directory, in whatever directory you're in when you initiate the process. For example, if you have the following file structure:
+```
+/my-project
+  /angular
+    /components
+    /services
+    /directives
+```
+If you're currently in the `my-project` directory and you generate a component called `example-component`, you will have the following structure:
+```
+/my-project
+  /angular
+    /components
+    /services
+    /directives
+  /components
+    /example-component
+      example-component.component.js
+      example-component.component.spec.js
+      example-component.html
+```
+Understanding that this is not the desired outcome, you should be sure that you navigate to the directory that you wish for the files to be generated in. In our above example, we should generate our files while in the `angular` directory.
 
 #### Component Generation
 Example:

--- a/generators/component.js
+++ b/generators/component.js
@@ -12,7 +12,7 @@ var component = require('../templates/component/component.js');
 var spec = require('../templates/component/component.spec.js');
 
 var formattedName;
-var location = 'lib/assets/javascripts/angular/mobi/components/';
+var location = process.cwd() + '/components/';
 var completed = [];
 
 exports.generate = function(name) {

--- a/generators/directive.js
+++ b/generators/directive.js
@@ -12,7 +12,7 @@ var factory = require('../templates/directive/directive.js');
 var spec = require('../templates/directive/directive.spec.js');
 
 var formattedName;
-var location = 'lib/assets/javascripts/angular/mobi/directives/';
+var location = process.cwd() + '/directives/';
 var completed = [];
 
 exports.generate = function(name) {

--- a/generators/factory.js
+++ b/generators/factory.js
@@ -11,7 +11,7 @@ var factory = require('../templates/factory/factory.js');
 var spec = require('../templates/factory/factory.spec.js');
 
 var formattedName;
-var location = 'lib/assets/javascripts/angular/mobi/services/';
+var location = process.cwd() + '/services/';
 var completed = [];
 
 exports.generate = function(name) {

--- a/index.js
+++ b/index.js
@@ -8,14 +8,9 @@ var directive = require('./generators/directive.js');
 var factory = require('./generators/factory.js');
 
 program
-  .version('0.0.1', '-v, --version')
+  .version('0.0.5', '-v, --version')
   .command('generate [type] [name]')
   .action(function (type, name) {
-    if (process.cwd().indexOf('pie') === -1) {
-      console.log(chalk.bold.red('**ERROR** Must be in the PIE directory'));
-      process.exit();
-    }
-
     if (availableTypes.indexOf(type) === -1) {
       throwUnknownType(type);
     }


### PR DESCRIPTION
This removes the dependency of being within the pie directory. This also
allows us to generate tests for our separate module types.

Now, the files will be generated in the directory of which the process
was invoked.